### PR TITLE
Fixes touch detection on Samsung Chrome by dropping hover: none check

### DIFF
--- a/src/components/layout/Hero/styles.tsx
+++ b/src/components/layout/Hero/styles.tsx
@@ -22,7 +22,7 @@ export const HeroContainer = styled.div`
     height: calc(100vh - (16px + (${({ theme }) => theme.spacing.xxl} * 2)));
   }
 
-  @media (hover: none) and (pointer: coarse) and (max-height: 500px) {
+  @media (pointer: coarse) and (max-height: 500px) {
     height: 100svh;
   }
 `;

--- a/src/components/sections/Contact/styles.tsx
+++ b/src/components/sections/Contact/styles.tsx
@@ -42,7 +42,7 @@ export const ContactContainer = styled.div`
     height: ${({ theme }) => theme.layout.viewport.sections.contact.fhd};
   }
 
-  @media (hover: none) and (pointer: coarse) and (max-height: 500px) {
+  @media (pointer: coarse) and (max-height: 500px) {
     min-height: 0;
     max-height: 100svh;
   }

--- a/src/components/sections/Projects/styles.tsx
+++ b/src/components/sections/Projects/styles.tsx
@@ -97,7 +97,7 @@ export const CarouselCard = styled.div<{
 export const MobileCounter = styled.div`
   width: 100%;
 
-  @media (hover: none) and (pointer: coarse) and (min-width: 600px) {
+  @media (pointer: coarse) and (min-width: 600px) {
     display: none;
   }
 `;
@@ -111,7 +111,7 @@ export const MobileCarouselContainer = styled.div`
   margin-left: 50%;
   transform: translateX(-50%);
 
-  @media (hover: none) and (pointer: coarse) {
+  @media (pointer: coarse) {
     display: flex;
   }
 `;
@@ -133,7 +133,7 @@ export const MobileScrollTrack = styled.div`
     display: none;
   }
 
-  @media (hover: none) and (pointer: coarse) and (min-width: 600px) {
+  @media (pointer: coarse) and (min-width: 600px) {
     padding: ${({ theme }) => theme.spacing.sm} 4%;
   }
 `;
@@ -143,7 +143,7 @@ export const MobileCardSlide = styled.div<{ $active: boolean; $side?: "left" | "
   flex: 0 0 82%;
   min-width: 0;
 
-  @media (hover: none) and (pointer: coarse) and (min-width: 600px) {
+  @media (pointer: coarse) and (min-width: 600px) {
     flex: 0 0 92%;
   }
   transform: ${({ $active }) => ($active ? "translateY(0)" : "translateY(4px)")};
@@ -151,7 +151,7 @@ export const MobileCardSlide = styled.div<{ $active: boolean; $side?: "left" | "
   filter: ${({ $active }) => ($active ? "none" : "brightness(0.7)")};
   transition: transform 0.3s ease, opacity 0.3s ease, filter 0.3s ease;
 
-  @media (hover: none) and (pointer: coarse) and (min-width: 600px) {
+  @media (pointer: coarse) and (min-width: 600px) {
     opacity: ${({ $active }) => ($active ? 1 : 0.9)};
     filter: ${({ $active }) => ($active ? "none" : "brightness(0.9)")};
   }
@@ -169,7 +169,7 @@ export const MobileCardSlide = styled.div<{ $active: boolean; $side?: "left" | "
 export const DesktopCardWrapper = styled.div`
   display: block;
 
-  @media (hover: none) and (pointer: coarse) {
+  @media (pointer: coarse) {
     display: none;
   }
 `;

--- a/src/components/ui-library/MobileCard/MobileCard.tsx
+++ b/src/components/ui-library/MobileCard/MobileCard.tsx
@@ -15,7 +15,7 @@ type MobileCardProps = {
 };
 
 const WIDE_TOUCH =
-  "@media (hover: none) and (pointer: coarse) and (min-width: 600px)";
+  "@media (pointer: coarse) and (min-width: 600px)";
 
 const Wrapper = styled.div`
   position: relative;


### PR DESCRIPTION
Samsung Chrome (and other Android browsers) can report hover: hover on phones, causing the combined query to miss. (pointer: coarse) alone is the reliable touch-primary signal.