### PR TITLE
Fixes landscape-mobile hero text clipping and contact scroll jank

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,7 @@ function App() {
               thumbnail: plixitImg,
               thumbnailWide: plixitWideImg,
               description:
-                "Multiplayer territory game built on a custom game engine (Kubic Kode). Real-time sync over WebSockets. Self-hosted Docker stack with Grafana/Loki monitoring, in-game playtesting pipeline, and a structured ship process.",
+                "Multiplayer territory game on Kubic Kode, a custom game engine. Self-hosted, monitored with Grafana/Loki.",
               techStack: ["React", "TypeScript", "Node.js", "Docker", "Grafana"],
               status: "Live \u2022 Active Development \u2022 2026",
               projectType: "Multiplayer Game",

--- a/src/components/layout/Hero/styles.tsx
+++ b/src/components/layout/Hero/styles.tsx
@@ -65,6 +65,10 @@ export const HeroTextContainer = styled.div`
   padding: 0;
   z-index: ${({ theme }) => theme.zIndex.content};
 
+  @media (pointer: coarse) and (max-height: 500px) {
+    height: 65%;
+  }
+
   ${mediaQuery.from("tablet")} {
     height: 50%;
   }

--- a/src/components/sections/Contact/styles.tsx
+++ b/src/components/sections/Contact/styles.tsx
@@ -3,7 +3,7 @@ import { mediaQuery } from "@/styles/theme/mediaQueries";
 
 export const ContactWrapper = styled.section`
   width: 100%;
-  height: 100dvh;
+  height: 100svh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -21,7 +21,7 @@ export const ContactContainer = styled.div`
   width: 100%;
   height: auto;
   min-height: 500px;
-  max-height: 80dvh;
+  max-height: 80svh;
   overflow-y: auto;
   text-align: center;
   position: relative;
@@ -44,7 +44,7 @@ export const ContactContainer = styled.div`
 
   @media (pointer: coarse) and (max-height: 500px) {
     min-height: 0;
-    max-height: 100dvh;
+    max-height: 100svh;
   }
 `;
 


### PR DESCRIPTION
- Hero: bumps HeroTextContainer to 65% in landscape-mobile so overflowing name/subtitle no longer gets pushed above the container and under the URL bar
- Contact: reverts dvh back to svh on ContactWrapper/Container, preventing the section from resizing mid-scroll as browser chrome toggles
- Shortens Plixit project description to keep Featured card lengths closer in length