### PR TITLE
Offsets hero by URL-bar overlay height in landscape mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Joakim Karlsson - Portfolio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { CircleDivider } from "@/components/layout/CircleDivider";
 import { Projects } from "@/components/sections/Projects";
 import { Contact } from "@/components/sections/Contact";
 import { Link } from "@/components/ui-library/Link";
+import { useUrlBarInset } from "@/hooks/useUrlBarInset";
 import plixitImg from "@/assets/images/projects/plixit.png";
 import plixitWideImg from "@/assets/images/projects/plixit_vertical_bg_2.png";
 import portfolioImg from "@/assets/images/projects/portfolio.png";
@@ -18,6 +19,8 @@ const ContentWrapper = styled.div`
 `;
 
 function App() {
+  useUrlBarInset();
+
   return (
     <DefaultThemeProvider>
       <>

--- a/src/components/layout/Hero/styles.tsx
+++ b/src/components/layout/Hero/styles.tsx
@@ -24,6 +24,7 @@ export const HeroContainer = styled.div`
 
   @media (pointer: coarse) and (max-height: 500px) {
     height: 100svh;
+    padding-top: var(--url-bar-inset, 0px);
   }
 `;
 

--- a/src/hooks/useUrlBarInset.ts
+++ b/src/hooks/useUrlBarInset.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+
+/**
+ * Mirrors the mobile browser URL-bar overlay height into the
+ * --url-bar-inset CSS custom property on <html>. Only non-zero when
+ * the URL bar overlays the viewport (iOS Safari / Samsung Chrome in
+ * landscape), so CSS can offset content without wasting space elsewhere.
+ */
+export const useUrlBarInset = (): void => {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const root = document.documentElement;
+
+    const update = () => {
+      const inset = Math.max(0, Math.round(vv.offsetTop));
+      root.style.setProperty("--url-bar-inset", `${inset}px`);
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, []);
+};


### PR DESCRIPTION
- Adds viewport-fit=cover so safe-area insets report correctly
- Adds useUrlBarInset hook mirroring visualViewport.offsetTop into a --url-bar-inset CSS variable
- Pads the hero by that inset in the landscape-mobile rule so the name no longer sits behind the Safari/Chrome URL bar overlay