### PR TITLE
Tunes Contact and MobileCard landscape layouts: lvh height on landsca…

### DIFF
--- a/src/components/sections/Contact/Contact.tsx
+++ b/src/components/sections/Contact/Contact.tsx
@@ -10,6 +10,7 @@ import {
   ContactButtonContainer,
   ContactInfo,
   ContactLinks,
+  ContactSocialText,
   VideoPlaceholder,
   ContactTitleTypography,
   ContactEmailWrapper,
@@ -112,9 +113,11 @@ export const Contact: React.FC<ContactProps> = ({
                       </Link>
                     </ContactEmailWrapper>
                   </Typography>
-                  <Typography variant="body" color="secondary">
-                    ...or reach out on social media{" "}
-                  </Typography>
+                  <ContactSocialText>
+                    <Typography variant="body" color="secondary">
+                      ...or reach out on social media{" "}
+                    </Typography>
+                  </ContactSocialText>
 
                   <ContactLinks>
                     <Link href={githubUrl} variant="default" external>

--- a/src/components/sections/Contact/styles.tsx
+++ b/src/components/sections/Contact/styles.tsx
@@ -12,6 +12,10 @@ export const ContactWrapper = styled.section`
   bottom: 0;
   background: ${({ theme }) => theme.colors.palette.primary};
   z-index: ${({ theme }) => theme.zIndex.sections.contact};
+
+  @media (pointer: coarse) and (max-height: 500px) {
+    height: 100lvh;
+  }
 `;
 
 export const ContactContainer = styled.div`
@@ -40,6 +44,11 @@ export const ContactContainer = styled.div`
 
   ${mediaQuery.from("fhd")} {
     height: ${({ theme }) => theme.layout.viewport.sections.contact.fhd};
+  }
+
+  @media (pointer: coarse) and (max-height: 500px) {
+    height: 80lvh;
+    max-height: 80lvh;
   }
 `;
 
@@ -91,6 +100,8 @@ export const ContactGrid = styled.div`
     display: flex;
     flex-direction: column;
     grid-template-columns: none;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
   }
 `;
 
@@ -192,6 +203,12 @@ export const ContactInfo = styled.div`
 
   > *:nth-child(2) {
     margin-bottom: ${({ theme }) => theme.spacing.md};
+  }
+`;
+
+export const ContactSocialText = styled.div`
+  @media (pointer: coarse) and (max-height: 500px) {
+    display: none;
   }
 `;
 

--- a/src/components/ui-library/MobileCard/MobileCard.tsx
+++ b/src/components/ui-library/MobileCard/MobileCard.tsx
@@ -30,6 +30,8 @@ const Wrapper = styled.div`
   ${WIDE_TOUCH} {
     max-width: 720px;
     min-height: calc(100svh - 140px);
+    display: flex;
+    flex-direction: column;
   }
 `;
 
@@ -46,6 +48,7 @@ const Landscape = styled.div`
 
   ${WIDE_TOUCH} {
     display: flex;
+    flex: 1;
     align-items: stretch;
   }
 `;


### PR DESCRIPTION
…pe mobile Contact, hides 'reach out on social media' text there, adds matching top/bottom padding, and stretches MobileCard landscape inner layout to fill Wrapper min-height on tablet